### PR TITLE
Updated MinSDK to 29 (Android 10) as Notes seem to be on that API

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId "io.github.karino2.pngnote"
-        minSdk 24
+        minSdk 29
         targetSdk 31
         versionCode 4
         versionName "0.4"

--- a/app/src/main/java/io/github/karino2/pngnote/BookListActivity.kt
+++ b/app/src/main/java/io/github/karino2/pngnote/BookListActivity.kt
@@ -100,13 +100,36 @@ class BookListActivity : ComponentActivity() {
     }
 
     private val bookSizeDP by lazy {
-        val metrics = DisplayMetrics()
-        windowManager.defaultDisplay.getMetrics(metrics)
+
+        var pixelHeight
+        var pixelWidth
+        var density
+
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+            val metrics = windowManager.maximumWindowMetrics
+
+            density = resources.displayMetrics.density
+            pixelHeight = metrics.bounds.height()
+            pixelWidth = metrics.bounds.width()
+
+        } else {
+            val metrics = DisplayMetrics()
+            @Suppress("DEPRECATION")
+            val display = windowManager.defaultDisplay
+            @Suppress("DEPRECATION")
+            display.getMetrics(metrics)
+
+            density = metrics.density
+            pixelHeight = metrics.heightPixels
+            pixelWidth = metrics.widthPixels
+        }
 
         // about half of 80%〜90%.
 
-        val height = (metrics.heightPixels*0.40/metrics.density).dp
-        val width = (metrics.widthPixels*0.45/metrics.density).dp
+        println("Pixelheight applied ${pixelHeight.toString()}")
+
+        val height = ((pixelHeight/density)*0.35).dp
+        val width = (pixelWidth*0.45/density).dp
 
         Pair(width, height)
     }


### PR DESCRIPTION
Refactored density calculation as old way is depreciated when API >30